### PR TITLE
Add f1 score

### DIFF
--- a/benchmarks/mnist/evaluation.py
+++ b/benchmarks/mnist/evaluation.py
@@ -17,9 +17,17 @@ def evaluate(
     for task in tasks:
         preds_ds = load_dataset(submission_dataset, task, use_auth_token=use_auth_token)
         acc = load_metric("accuracy")
+        f1 = load_metric("f1")
         for split in test_ds.keys():
             metrics[task][split] = acc.compute(
                 predictions=preds_ds[split]["preds"], references=test_ds[split]["label"]
+            )
+            metrics[task][split].update(
+                f1.compute(
+                    predictions=preds_ds[split]["preds"],
+                    references=test_ds[split]["label"],
+                    average="macro",
+                )
             )
     return metrics
 


### PR DESCRIPTION
This PR adds an F1 score the the evaluation outputs so we now get

```
defaultdict(dict,
            {'task1': {'train': {'accuracy': 1.0, 'f1': 1.0},
              'test': {'accuracy': 0.9696, 'f1': 0.969386155333814}},
             'task2': {'train': {'accuracy': 1.0, 'f1': 1.0},
              'test': {'accuracy': 0.9696, 'f1': 0.969386155333814}}})
```

cc @abhishekkrthakur 