### PR TITLE
Refactor evaluate function signatures to match autonlp

### DIFF
--- a/benchmarks/mnist/evaluation.py
+++ b/benchmarks/mnist/evaluation.py
@@ -5,11 +5,14 @@ from datasets import load_dataset, load_metric
 
 
 def evaluate(
-    test_dataset: str = "mnist", submission_dataset: str = "lewtun/mnist-preds", use_auth_token: bool = False, **kwargs
+    evaluation_dataset: str = "mnist",
+    submission_dataset: str = "lewtun/mnist-preds",
+    use_auth_token: bool = False,
+    **kwargs
 ) -> List[Dict[str, Dict]]:
     metrics = []
     tasks = ["task1", "task2"]
-    test_ds = load_dataset(test_dataset, use_auth_token=use_auth_token)
+    test_ds = load_dataset(evaluation_dataset, use_auth_token=use_auth_token)
     for task in tasks:
         task_data = {task: []}
         preds_ds = load_dataset(submission_dataset, task, use_auth_token=use_auth_token)

--- a/benchmarks/raft/evaluation.py
+++ b/benchmarks/raft/evaluation.py
@@ -8,12 +8,12 @@ def convert_labels_to_ids(example):
 
 
 def evaluate(
-    test_dataset: str, submission_dataset: str, use_auth_token: str = None, **kwargs
+    evaluation_dataset: str, submission_dataset: str, use_auth_token: str = None, **kwargs
 ) -> List[Dict[str, List]]:
     """Computes metrics for a benchmark.
 
     Args:
-        test_dataset (:obj:`str`): Name of private dataset with ground truth labels.
+        evaluation_dataset (:obj:`str`): Name of private dataset with ground truth labels.
         submission_dataset (:obj:`str`): Name of user submission dataset with model predictions.
         use_auth_token (:obj:`str`): The API token to access your private dataset on the Hugging Face Hub.
 
@@ -32,7 +32,7 @@ def evaluate(
     for task in tasks:
         task_data = {task: []}
         # Load datasets associated with task
-        evaluation_ds = load_dataset(path=test_dataset, name=task, use_auth_token=use_auth_token)
+        evaluation_ds = load_dataset(path=evaluation_dataset, name=task, use_auth_token=use_auth_token)
         submission_ds = load_dataset(path=submission_dataset, name=task, use_auth_token=use_auth_token)
         # Sort by title for alignment
         evaluation_ds = evaluation_ds.sort("title")


### PR DESCRIPTION
This PR refactors the function signature of evaluation functions to a) be more generic in description and b) match the autonlp backend.