### PR TITLE
Replace HF Hub usage with native requests

### DIFF
--- a/benchmarks/superb/evaluation.py
+++ b/benchmarks/superb/evaluation.py
@@ -1,14 +1,18 @@
 from typing import Dict, List
 
+import requests
 from datasets import load_dataset, load_metric
-from huggingface_hub import HfApi
 
 
 def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: str) -> List[Dict[str, List]]:
-    api = HfApi()
-    info = api.dataset_info(submission_dataset, token=use_auth_token)
-    task = [t.split(":")[1] for t in info.tags if t.split(":")[0] == "task"][0]
+    # Extract task associated with submission dataset
+    header = {"Authorization": "Bearer " + use_auth_token}
+    response = requests.get("http://huggingface.co/api/datasets/lewtun/asr-preds-test", headers=header)
+    info = response.json()
+    task = [t.split(":")[1] for t in info["tags"] if t.split(":")[0] == "task"][0]
+
     eval_ds = load_dataset(evaluation_dataset, task, split="test", use_auth_token=use_auth_token)
+    # TODO(lewtun): Use dataset loading script instead of relying on hard-coded paths
     sub_ds = load_dataset(
         "json",
         data_files=f"https://huggingface.co/datasets/{submission_dataset}/resolve/main/preds.jsonl",


### PR DESCRIPTION
This PR removes the dependency on `huggingface_hub` in the `superb` evaluation because we were hitting dependency conflicts on the `autonlp` side. See this [PR](https://github.com/huggingface/transformers/pull/12961) for more details.