### PR TITLE
Add type checking

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -1,0 +1,28 @@
+name: Python quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_code_quality:
+    name: Check code quality
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python environment
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[quality]"
+    - name: Code quality
+      run: |
+      make quality
+      make typecheck

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Test benchmarks
+name: Benchmark tests
 
 on:
   push:
@@ -26,19 +26,3 @@ jobs:
           python -m pip install ".[tests]"
       - name: Run unit tests
         run: pytest
-
-  check_code_quality:
-    name: Check code quality
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python environment
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ".[quality]"
-    - name: Code quality
-      run: make quality

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ quality:
 	python -m black --check --line-length 119 --target-version py39 .
 	python -m isort --check-only .
 	python -m flake8 --max-line-length 119
+
+typecheck:
+	python -m mypy ./benchmarks

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ DOCLINES = __doc__.split("\n")
 
 REQUIRED_PKGS = ["datasets==1.11.0"]
 
-QUALITY_REQUIRE = ["black", "flake8", "isort", "pyyaml>=5.3.1"]
+QUALITY_REQUIRE = ["black", "flake8", "isort", "pyyaml>=5.3.1", "mypy"]
 
 TESTS_REQUIRE = ["pytest", "pytest-cov"]
 


### PR DESCRIPTION
This PR refactors the evaluation schemas to use `TypedDict` instead of `dataclass` to be able to enforce type checking on the `evaluate` functions for each benchmark

One unusual thing is that _importing_ `TypedDict` "classes" from a separate module like `evaluate.schemas` does not trigger `mypy` errors when these "classes" are instantiated inside the `evaluate` function. Presumably this is because `TypedDict` is not a class per se, so for now we just copy-paste these classes inside each benchmark