### PR TITLE
Disable mypy for datasets code

### DIFF
--- a/benchmarks/common/evaluation.py
+++ b/benchmarks/common/evaluation.py
@@ -29,7 +29,9 @@ def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: s
         evaluation_ds = load_dataset(path=evaluation_dataset, name=task_name, use_auth_token=use_auth_token)
         submission_ds = load_dataset(path=submission_dataset, name=task_name, use_auth_token=use_auth_token)
         # Compute metrics and build up list of dictionaries, one per task in your benchmark
-        value = your_metric.compute(predictions=submission_ds["preds_column"], references=evaluation_ds["targets_column"])  # type: ignore
+        value = your_metric.compute(
+            predictions=submission_ds["preds_column"], references=evaluation_ds["targets_column"]
+        )
         metric = Metric(name="your_metric_name", type="your_metric_name", value=value)
         task["metrics"].append(metric)
         # Collect results

--- a/benchmarks/raft/evaluation.py
+++ b/benchmarks/raft/evaluation.py
@@ -33,8 +33,8 @@ def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: s
         evaluation_ds = load_dataset(path=evaluation_dataset, name=task, use_auth_token=use_auth_token)
         submission_ds = load_dataset(path=submission_dataset, name=task, use_auth_token=use_auth_token)
         # Sort by title for alignment
-        evaluation_ds = evaluation_ds.sort("title")  # type: ignore
-        submission_ds = submission_ds.sort("title")  # type: ignore
+        evaluation_ds = evaluation_ds.sort("title")
+        submission_ds = submission_ds.sort("title")
         # Create label IDs
         # TODO(lewtun): use ClassLabel type on Dataset side to skip this
         evaluation_ds = evaluation_ds.map(convert_labels_to_ids)
@@ -45,7 +45,7 @@ def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: s
             references=evaluation_ds["test"]["label"],
             average="binary",
         )
-        for k, v in scores.items():  # type: ignore
+        for k, v in scores.items():
             task_data["metrics"].append(Metric(name=k, type=k, value=v))
         # Collect results
         result = Result(task=task_data)

--- a/benchmarks/superb/evaluation.py
+++ b/benchmarks/superb/evaluation.py
@@ -27,7 +27,7 @@ def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: s
         task = Task(name=task_name, type="automatic-speech-recognition", metrics=[])
         # Compute metrics
         wer_metric = load_metric("wer")
-        value = wer_metric.compute(predictions=submission_ds["text"], references=evaluation_ds["text"])  # type: ignore
+        value = wer_metric.compute(predictions=submission_ds["text"], references=evaluation_ds["text"])
         task["metrics"].append(Metric(name="wer", type="wer", value=value))
         # Collect results
         result = Result(task=task)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [mypy]
-ignore_missing_imports = True
+[mypy-datasets]
+follow_imports = skip
 
 [isort]
 multi_line_output = 3


### PR DESCRIPTION
This PR disables `mypy` type-checking for code which relies on `datasets`. `mypy` produces spurious errors with `IterableDataset` types, so we ignore this globally in the config