### PR TITLE
Add new RAFT tasks with dummy scores

### DIFF
--- a/benchmarks/raft/evaluation.py
+++ b/benchmarks/raft/evaluation.py
@@ -1,6 +1,7 @@
+import numpy as np
 from datasets import load_dataset, load_metric
 
-from evaluate import Evaluation, Metric, Result, Task
+from evaluate import Evaluation, Metric, Result, Task, get_benchmark_tasks
 
 
 def convert_labels_to_ids(example):
@@ -20,7 +21,7 @@ def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: s
     """
 
     # If your benchmark has multiple tasks, define their names here
-    tasks = ["TAISafety-binary"]
+    tasks = get_benchmark_tasks(evaluation_dataset)
     # Load metric
     # TODO(lewtun): add more metrics!
     f1 = load_metric("f1")
@@ -29,24 +30,27 @@ def evaluate(evaluation_dataset: str, submission_dataset: str, use_auth_token: s
     # Iterate over tasks and build up metrics
     for task in tasks:
         task_data = Task(name=task, type="text-classification", metrics=[])
-        # Load datasets associated with task
-        evaluation_ds = load_dataset(path=evaluation_dataset, name=task, use_auth_token=use_auth_token)
-        submission_ds = load_dataset(path=submission_dataset, name=task, use_auth_token=use_auth_token)
-        # Sort by title for alignment
-        evaluation_ds = evaluation_ds.sort("title")
-        submission_ds = submission_ds.sort("title")
-        # Create label IDs
-        # TODO(lewtun): use ClassLabel type on Dataset side to skip this
-        evaluation_ds = evaluation_ds.map(convert_labels_to_ids)
-        submission_ds = submission_ds.map(convert_labels_to_ids)
-        # Compute metrics and build up list of dictionaries, one per task in your benchmark
-        scores = f1.compute(
-            predictions=submission_ds["test"]["label"],
-            references=evaluation_ds["test"]["label"],
-            average="binary",
-        )
-        for k, v in scores.items():
-            task_data["metrics"].append(Metric(name=k, type=k, value=v))
+        if task == "TAISafety-binary":
+            # Load datasets associated with task
+            evaluation_ds = load_dataset(path=evaluation_dataset, name=task, use_auth_token=use_auth_token)
+            submission_ds = load_dataset(path=submission_dataset, name=task, use_auth_token=use_auth_token)
+            # Sort by title for alignment
+            evaluation_ds = evaluation_ds.sort("title")
+            submission_ds = submission_ds.sort("title")
+            # Create label IDs
+            # TODO(lewtun): use ClassLabel type on Dataset side to skip this
+            evaluation_ds = evaluation_ds.map(convert_labels_to_ids)
+            submission_ds = submission_ds.map(convert_labels_to_ids)
+            # Compute metrics and build up list of dictionaries, one per task in your benchmark
+            scores = f1.compute(
+                predictions=submission_ds["test"]["label"],
+                references=evaluation_ds["test"]["label"],
+                average="binary",
+            )
+            for k, v in scores.items():
+                task_data["metrics"].append(Metric(name=k, type=k, value=np.random.random()))
+        else:
+            task_data["metrics"].append(Metric(name="f1", type="f1", value=np.random.random()))
         # Collect results
         result = Result(task=task_data)
         evaluation["results"].append(result)

--- a/evaluate/__init__.py
+++ b/evaluate/__init__.py
@@ -1,1 +1,2 @@
 from .schemas import Evaluation, Metric, Result, Task
+from .utils import get_benchmark_tasks

--- a/evaluate/utils.py
+++ b/evaluate/utils.py
@@ -1,0 +1,7 @@
+from datasets import import_main_class, prepare_module
+
+
+def get_benchmark_tasks(dataset):
+    module, _ = prepare_module(dataset)
+    builder_cls = import_main_class(module)
+    return list(builder_cls.builder_configs.keys())


### PR DESCRIPTION
This PR adds a helper `get_benchmark_tasks` to grab all the tasks in the evaluation dataset and uses it to populate the RAFT evaluation with dummy scores until the evaluation protocol is defined