### PR TITLE
Bump datasets version

### DIFF
--- a/benchmarks/gem/requirements.txt
+++ b/benchmarks/gem/requirements.txt
@@ -1,2 +1,2 @@
-datasets==1.11.0 # DO NOT CHANGE!
+datasets==1.17.0 # DO NOT CHANGE!
 gem-metrics @ git+https://github.com/lewtun/GEM-metrics.git@use_hf_hub_references

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ from setuptools import find_packages, setup
 DOCLINES = __doc__.split("\n")
 
 # We must upper bound the datasets version to match that in the autonlp backend
-REQUIRED_PKGS = ["datasets>=1.9.0,<=1.11.0", "typer>=0.3.2", "python-dotenv>=0.18.0"]
+REQUIRED_PKGS = ["datasets<=1.17.0", "typer>=0.3.2", "python-dotenv>=0.18.0"]
 
 QUALITY_REQUIRE = ["black", "flake8", "isort", "pyyaml>=5.3.1", "mypy", "types-requests"]
 


### PR DESCRIPTION
This PR bumps the `datasets` version to match that in the AutoNLP backend