### PR TITLE
Fix GEM permission errors

### DIFF
--- a/benchmarks/gem/evaluation.py
+++ b/benchmarks/gem/evaluation.py
@@ -27,6 +27,8 @@ def compute_metrics(evaluation_dataset: str, submission_dataset: str, use_auth_t
     process = subprocess.run(
         ["gem_metrics", f"{submission_filepath}", "-o", f"{metrics_filename}"],
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True,
     )
     if process.returncode == -1:
         raise ValueError(f"Error running gem_metrics for submission {submission_dataset} on {evaluation_dataset}!")

--- a/scripts/run_evaluation_dummy.py
+++ b/scripts/run_evaluation_dummy.py
@@ -24,7 +24,7 @@ app = typer.Typer()
 @app.command()
 def run(
     benchmark: str = "dummy",
-    evaluation_dataset: str = "lewtun/benchmarks-private-label",
+    evaluation_dataset: str = "lewtun/benchmarks-dummy-private-labels",
     end_date: str = "2022-06-22",
     previous_days: int = 7,
 ):
@@ -49,7 +49,7 @@ def run(
         timestamp = pd.to_datetime(data["lastModified"])
         submission_timestamp = int(timestamp.tz_localize(None).timestamp())
         # Use the user-generated submission name, Git commit SHA and timestamp to create submission ID
-        submission_id = submission_name + "__" + uuid.uuid4()[:6] + "__" + str(submission_timestamp)
+        submission_id = submission_name + "__" + str(uuid.uuid4())[:6] + "__" + str(submission_timestamp)
         # Define AutoTrain payload
         project_config = {}
         # Need a dummy dataset to use the dataset loader in AutoTrain

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -75,7 +75,6 @@ class GetBenchmarkReposTest(TestCase):
         data = get_benchmark_repos(
             benchmark=DUMMY_BENCHMARK_NAME, use_auth_token=True, endpoint="datasets", repo_type="evaluation"
         )
-        self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["id"], DUMMY_EVALUATION_ID)
 
     def test_model_upload_repo(self):


### PR DESCRIPTION
This PR attempts to fix a permission error that arises when computing GEM metrics within AutoTrain:

```
Traceback (most recent call last):
  File "/app/env/bin/gem_metrics", line 8, in <module>
    sys.exit(main())
  File "/app/env/lib/python3.8/site-packages/gem_metrics/__init__.py", line 566, in main
    process_files(config)
  File "/app/env/lib/python3.8/site-packages/gem_metrics/__init__.py", line 475, in process_files
    out_fh = open(config.output_file, "w", encoding="UTF-8")

PermissionError: [Errno 13] Permission denied: 'metrics.json'
```