### PR TITLE
Add backend API status

### DIFF
--- a/.github/workflows/run_raft_evaluation.yaml
+++ b/.github/workflows/run_raft_evaluation.yaml
@@ -34,7 +34,8 @@ jobs:
           MONTH: "${{ steps.current-time.outputs.month }}"
           DAY: "${{ steps.current-time.outputs.day }}"
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          AUTOTRAIN_USERNAME : ${{ secrets.AUTOTRAIN_USERNAME }}
           AUTOTRAIN_TOKEN: ${{ secrets.AUTOTRAIN_TOKEN }}
           AUTOTRAIN_BACKEND_API: ${{ secrets.AUTOTRAIN_BACKEND_API }}
         run: |
-          HF_TOKEN=$HF_TOKEN AUTOTRAIN_TOKEN=$AUTOTRAIN_TOKEN AUTOTRAIN_BACKEND_API=$AUTOTRAIN_BACKEND_API python scripts/run_evaluation.py raft ought/raft-private-labels $YEAR-$MONTH-$DAY 7
+          HF_TOKEN=$HF_TOKEN AUTOTRAIN_USERNAME=$AUTOTRAIN_USERNAME AUTOTRAIN_TOKEN=$AUTOTRAIN_TOKEN AUTOTRAIN_BACKEND_API=$AUTOTRAIN_BACKEND_API python scripts/run_evaluation.py raft ought/raft-private-labels $YEAR-$MONTH-$DAY 7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Hugging Face Benchmarks
+
 > A toolkit for evaluating benchmarks on the [Hugging Face Hub](https://huggingface.co)
+
+## Hosted benchmarks
+
+The list of hosted benchmarks is shown in the table below:
+
+| Benchmark | Description | Submission | Leaderboard |
+| :---: | :---: | :---: | :---: | 
+| RAFT | A benchmark to test few-shot learning in NLP | [`ought/raft-submission`](https://huggingface.co/datasets/ought/raft-submission) | [`ought/raft-leaderboard`](https://huggingface.co/spaces/ought/raft-leaderboard) |
+| GEM | A large-scale benchmark for natural language generation | [`GEM/submission-form`](https://huggingface.co/spaces/GEM/submission-form) | [`GEM/results`](https://huggingface.co/spaces/GEM/results) |
 
 ## Developer installation
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,10 @@
-## Adding a new benchmark for evaluation 
+# Hugging Face Benchmarks
 
-1. Copy the contents of the `common/` folder into a folder with your benchmark's name, e.g. `my_benchmark/`
-2. Edit:
-    * `my_benchmark/requirements.txt`
-    * `my_benchmark/evaluation.py`
+## AutoTrain configuration details
+
+Benchmarks are evaluated by AutoTrain, with the payload sent to the `AUTOTRAIN_BACKEND_API` environment variable. The current configuration for the hosted benchmarks is shown in the table below.
+
+| Benchmark |                  Backend API                   |
+|:---------:|:----------------------------------------------:|
+|   RAFT    | `https://api-staging.autotrain.huggingface.co` |
+|    GEM    | `https://api-staging.autotrain.huggingface.co` |


### PR DESCRIPTION
This PR adds some basic info on which AutoTrain endpoint each benchmark is calling. Useful for distinguishing between changes in `prod` and `staging` envs.

It also fixes a small bug in the GitHub action for RAFT evaluations (missing env var)