### PR TITLE
Fix AutoTrain project creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ quality:
 	python -m black --check --line-length 119 --target-version py39 .
 	python -m isort --check-only .
 	python -m flake8 --max-line-length 119
+	python -m mypy ./benchmarks
 
 typecheck-benchmarks:
 	python -m mypy ./benchmarks

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ quality:
 	python -m black --check --line-length 119 --target-version py39 .
 	python -m isort --check-only .
 	python -m flake8 --max-line-length 119
-	python -m mypy ./benchmarks
 
 typecheck-benchmarks:
 	python -m mypy ./benchmarks

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -51,6 +51,7 @@ def run(benchmark: str, evaluation_dataset: str, end_date: str, previous_days: i
         # Define AutoTrain payload
         project_config = {}
         # Need a dummy dataset to use the dataset loader in AutoTrain
+        # Derived from the `emotion` dataset => multiclass classification task
         project_config["dataset_name"] = "autoevaluator/benchmark-dummy-data"
         project_config["dataset_config"] = "autoevaluator--benchmark-dummy-data"
         project_config["dataset_split"] = "train"
@@ -64,7 +65,7 @@ def run(benchmark: str, evaluation_dataset: str, end_date: str, previous_days: i
         payload = {
             "username": AUTOTRAIN_USERNAME,
             "proj_name": submission_id,
-            "task": 1,
+            "task": 2,  # Need multi-class classification task to align with dummy dataset
             "config": {
                 "language": "en",
                 "max_models": 5,

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ REQUIRED_PKGS = [
     "python-dotenv>=0.18.0",
     "evaluate==0.1.2",
     "scikit-learn==1.1.1",
+    "huggingface-hub==0.10.1",
 ]
 
 QUALITY_REQUIRE = ["black", "flake8", "isort", "pyyaml>=5.3.1", "mypy", "types-requests"]


### PR DESCRIPTION
The dummy dataset we use for creating benchmark jobs in AutoTrain is multiclass which is incompatible with the task ID 1 used to create the project. This was causing the RAFT evaluation jobs to fail ([example](https://github.com/huggingface/hf_benchmarks/actions/runs/3453123516/jobs/5763476220))

This PR fixes that.

cc @abhishekkrthakur 